### PR TITLE
Remove anomalySequence from AnomalyDetectionModel#detect

### DIFF
--- a/src/main/java/com/yahoo/egads/control/AnomalyDetector.java
+++ b/src/main/java/com/yahoo/egads/control/AnomalyDetector.java
@@ -147,15 +147,14 @@ public class AnomalyDetector {
         }
     }
 
-    public void tune(TimeSeries.DataSequence expectedValues,
-            IntervalSequence anomalySequence) throws Exception {
+    public void tune(TimeSeries.DataSequence expectedValues) throws Exception {
         int i = 0;
 
         metric.data.setLogicalIndices(firstTimeStamp, period);
 
         for (AnomalyDetectionModel model : models) {
             if (!isTuned.get(i)) {
-                model.tune(metric.data, expectedValues, anomalySequence);
+                model.tune(metric.data, expectedValues);
                 isTuned.set(i, true);
             }
             i++;

--- a/src/main/java/com/yahoo/egads/control/DetectAnomalyProcessable.java
+++ b/src/main/java/com/yahoo/egads/control/DetectAnomalyProcessable.java
@@ -51,7 +51,7 @@ public class DetectAnomalyProcessable implements ProcessableObject {
             ad.reset();
 
             // Unsupervised tuning of the anomaly detectors
-            ad.tune(ds, null);
+            ad.tune(ds);
 
             // Detecting anomalies for each anomaly detection model in anomaly detector
             anomalyList = ad.detect(ad.metric, ds);

--- a/src/main/java/com/yahoo/egads/models/adm/AdaptiveKernelDensityChangePointDetector.java
+++ b/src/main/java/com/yahoo/egads/models/adm/AdaptiveKernelDensityChangePointDetector.java
@@ -131,7 +131,7 @@ public class AdaptiveKernelDensityChangePointDetector extends AnomalyDetectionAb
     }
 
     @Override
-    public void tune(DataSequence observedSeries, DataSequence expectedSeries, IntervalSequence anomalySequence)
+    public void tune(DataSequence observedSeries, DataSequence expectedSeries)
                     throws Exception {
 
     }

--- a/src/main/java/com/yahoo/egads/models/adm/AnomalyDetectionModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/AnomalyDetectionModel.java
@@ -20,8 +20,7 @@ public interface AnomalyDetectionModel extends Model {
 
     // tune the anomaly detection parameters based on the training data.
     public void tune(TimeSeries.DataSequence observedSeries,
-            TimeSeries.DataSequence expectedSeries,
-            Anomaly.IntervalSequence anomalySequence) throws Exception;
+            TimeSeries.DataSequence expectedSeries) throws Exception;
 
     // method to check whether the anomaly value is inside the
     // detection window or not

--- a/src/main/java/com/yahoo/egads/models/adm/DBScanModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/DBScanModel.java
@@ -83,8 +83,7 @@ public class DBScanModel extends AnomalyDetectionAbstractModel {
 
     @Override
     public void tune(DataSequence observedSeries,
-                     DataSequence expectedSeries,
-                     IntervalSequence anomalySequence) throws Exception {
+                     DataSequence expectedSeries) throws Exception {
         // Compute the time-series of errors.
         HashMap<String, ArrayList<Float>> allErrors = aes.initAnomalyErrors(observedSeries, expectedSeries);
         List<IdentifiedDoublePoint> points = new ArrayList<IdentifiedDoublePoint>();

--- a/src/main/java/com/yahoo/egads/models/adm/ExtremeLowDensityModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/ExtremeLowDensityModel.java
@@ -73,8 +73,7 @@ public class ExtremeLowDensityModel extends AnomalyDetectionAbstractModel {
 
     @Override
     public void tune(DataSequence observedSeries,
-                     DataSequence expectedSeries,
-                     IntervalSequence anomalySequence) throws Exception {
+                     DataSequence expectedSeries) throws Exception {
         // Compute the time-series of errors.
         HashMap<String, ArrayList<Float>> allErrors = aes.initAnomalyErrors(observedSeries, expectedSeries);
         

--- a/src/main/java/com/yahoo/egads/models/adm/KSigmaModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/KSigmaModel.java
@@ -73,8 +73,7 @@ public class KSigmaModel extends AnomalyDetectionAbstractModel {
     }
 
     @Override
-    public void tune(DataSequence observedSeries, DataSequence expectedSeries,
-            IntervalSequence anomalySequence) throws Exception {
+    public void tune(DataSequence observedSeries, DataSequence expectedSeries) throws Exception {
         HashMap<String, ArrayList<Float>> allErrors = aes.initAnomalyErrors(observedSeries, expectedSeries);
 
         for (int i = 0; i < (aes.getIndexToError().keySet()).size(); i++) {

--- a/src/main/java/com/yahoo/egads/models/adm/NaiveModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/NaiveModel.java
@@ -80,8 +80,7 @@ public class NaiveModel extends AnomalyDetectionAbstractModel {
     }
 
     @Override
-    public void tune(DataSequence observedSeries, DataSequence expectedSeries,
-            IntervalSequence anomalySequence) throws Exception {
+    public void tune(DataSequence observedSeries, DataSequence expectedSeries) throws Exception {
         // TODO: auto detect thresholds.
     }
     // Returns true this point is identified as a potential anomaly.

--- a/src/main/java/com/yahoo/egads/models/adm/SimpleThresholdModel.java
+++ b/src/main/java/com/yahoo/egads/models/adm/SimpleThresholdModel.java
@@ -68,8 +68,7 @@ public class SimpleThresholdModel extends AnomalyDetectionAbstractModel {
     }
 
     @Override
-    public void tune(DataSequence observedSeries, DataSequence expectedSeries,
-            IntervalSequence anomalySequence) throws Exception {  
+    public void tune(DataSequence observedSeries, DataSequence expectedSeries) throws Exception {
         Float thr[] = null;
         if (simpleThrType.equals("AdaptiveKSigmaSensitivity")) {
             thr = AutoSensitivity.getAdaptiveKSigmaSensitivity(observedSeries.getValues(), amntAutoSensitivity); 

--- a/src/test/java/com/yahoo/egads/TestAnomalyDetect.java
+++ b/src/test/java/com/yahoo/egads/TestAnomalyDetect.java
@@ -6,18 +6,14 @@
 
 package com.yahoo.egads;
 
-import com.yahoo.egads.data.Model;
 import com.yahoo.egads.models.tsmm.OlympicModel;
 import com.yahoo.egads.models.adm.*;
 import com.yahoo.egads.data.Anomaly.IntervalSequence;
-import com.yahoo.egads.utilities.*;
 import com.yahoo.egads.data.*;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import com.yahoo.egads.control.ProcessableObject;
-import com.yahoo.egads.control.ProcessableObjectFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -59,13 +55,13 @@ public class TestAnomalyDetect {
                  // Initialize the DBScan anomaly detector.
                  DBScanModel dbs = new DBScanModel(p);
                  IntervalSequence anomalies = bcm.detect(actual_metric.get(0).data, sequence);
-                 dbs.tune(actual_metric.get(0).data, sequence, null);
+                 dbs.tune(actual_metric.get(0).data, sequence);
                  IntervalSequence anomaliesdb = dbs.detect(actual_metric.get(0).data, sequence);
 
                  // Initialize the SimpleThreshold anomaly detector.
                  SimpleThresholdModel stm = new SimpleThresholdModel(p);
 
-                 stm.tune(actual_metric.get(0).data, sequence, null);
+                 stm.tune(actual_metric.get(0).data, sequence);
                  IntervalSequence anomaliesstm = stm.detect(actual_metric.get(0).data, sequence);
                  Assert.assertTrue(anomalies.size() > 10);
                  Assert.assertTrue(anomaliesdb.size() > 2);


### PR DESCRIPTION
`anomalySequence` was always set to null so this PR removes it to clarify the interface